### PR TITLE
Crazy workload version tab-completion idea

### DIFF
--- a/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
+++ b/src/Cli/dotnet/commands/InstallingWorkloadCommand.cs
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.Workloads.Workload
                 }
             }
 
-            string resolvedWorkloadSetVersion = _workloadSetVersionFromGlobalJson ??_workloadSetVersionFromCommandLine;
+            string resolvedWorkloadSetVersion = _workloadSetVersionFromGlobalJson ?? _workloadSetVersionFromCommandLine;
             if (string.IsNullOrWhiteSpace(resolvedWorkloadSetVersion) && !UseRollback && !FromHistory)
             {
                 _workloadManifestUpdater.UpdateAdvertisingManifestsAsync(_includePreviews, updateToLatestWorkloadSet, offlineCache).Wait();
@@ -423,10 +423,14 @@ namespace Microsoft.DotNet.Workloads.Workload
 
     internal static class InstallingWorkloadCommandParser
     {
-        public static readonly CliOption<string> WorkloadSetVersionOption = new("--version")
+        public static readonly CliOption<string> WorkloadSetVersionOption = new CliOption<string>("--version")
         {
             Description = Strings.WorkloadSetVersionOptionDescription
-        };
+        }.AddCompletions((ctx) =>
+        {
+            var versions = Search.Versions.SearchWorkloadSetsCommand.GetWorkloadSetVersions(ctx).GetAwaiter().GetResult();
+            return versions.Select(v => new System.CommandLine.Completions.CompletionItem(v));
+        });
 
         public static readonly CliOption<bool> PrintDownloadLinkOnlyOption = new("--print-download-link-only")
         {

--- a/src/Cli/dotnet/commands/dotnet-complete/CompleteCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-complete/CompleteCommand.cs
@@ -60,8 +60,8 @@ namespace Microsoft.DotNet.Cli
 
             var result = Parser.Instance.Parse(input);
 
-            return result.GetCompletions(position)
-                .Distinct()
+            var completions = result.GetCompletions(position);
+            return completions.Distinct()
                 .ToArray();
         }
     }

--- a/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/WorkloadSearchCommand.cs
@@ -2,26 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Text.Json;
-using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli;
-using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Workloads.Workload.Install;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Microsoft.DotNet.Workloads.Workload.Search
 {
     internal class WorkloadSearchCommand : WorkloadCommandBase
     {
         private readonly IWorkloadResolver _workloadResolver;
-        private readonly ReleaseVersion _sdkVersion;
         private readonly string _workloadIdStub;
-        private readonly int _numberOfWorkloadSetsToTake;
-        private readonly string _workloadSetOutputFormat;
-        private readonly IWorkloadManifestInstaller _installer;
-        internal bool ListWorkloadSetVersions { get; set; } = false;
 
         public WorkloadSearchCommand(
             ParseResult result,
@@ -31,53 +22,17 @@ namespace Microsoft.DotNet.Workloads.Workload.Search
             _workloadIdStub = result.GetValue(WorkloadSearchCommandParser.WorkloadIdStubArgument);
 
             workloadResolverFactory = workloadResolverFactory ?? new WorkloadResolverFactory();
+            var creationResult = workloadResolverFactory.Create();
+            _workloadResolver = creationResult.WorkloadResolver;
 
             if (!string.IsNullOrEmpty(result.GetValue(WorkloadSearchCommandParser.VersionOption)))
             {
                 throw new GracefulException(Install.LocalizableStrings.SdkVersionOptionNotSupported);
             }
-
-            var creationResult = workloadResolverFactory.Create();
-
-            _sdkVersion = creationResult.SdkVersion;
-            _workloadResolver = creationResult.WorkloadResolver;
-
-            _numberOfWorkloadSetsToTake = result.GetValue(SearchWorkloadSetsParser.TakeOption);
-            _workloadSetOutputFormat = result.GetValue(SearchWorkloadSetsParser.FormatOption);
-
-            _installer = WorkloadInstallerFactory.GetWorkloadInstaller(
-                reporter,
-                new SdkFeatureBand(_sdkVersion),
-                _workloadResolver,
-                Verbosity,
-                creationResult.UserProfileDir,
-                !SignCheck.IsDotNetSigned(),
-                restoreActionConfig: new RestoreActionConfig(result.HasOption(SharedOptions.InteractiveOption)),
-                elevationRequired: false,
-                shouldLog: false);
         }
 
         public override int Execute()
         {
-            if (ListWorkloadSetVersions)
-            {
-                var featureBand = new SdkFeatureBand(_sdkVersion);
-                var packageId = _installer.GetManifestPackageId(new ManifestId("Microsoft.NET.Workloads"), featureBand);
-                var versions = PackageDownloader.GetLatestPackageVersions(packageId, _numberOfWorkloadSetsToTake, packageSourceLocation: null, includePreview: !string.IsNullOrWhiteSpace(_sdkVersion.Prerelease))
-                    .GetAwaiter().GetResult()
-                    .Select(version => WorkloadManifestUpdater.WorkloadSetPackageVersionToWorkloadSetVersion(featureBand, version.Version.ToString()));
-                if (_workloadSetOutputFormat?.Equals("json", StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => version.ToDictionary(_ => "workloadVersion", v => v))));
-                }
-                else
-                {
-                    Reporter.WriteLine(string.Join('\n', versions));
-                }
-
-                return 0;
-            }
-
             IEnumerable<WorkloadResolver.WorkloadInfo> availableWorkloads = _workloadResolver.GetAvailableWorkloads()
                 .OrderBy(workload => workload.Id);
 

--- a/src/Cli/dotnet/commands/dotnet-workload/search/versions/SearchWorkloadSetsCommand.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/versions/SearchWorkloadSetsCommand.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Completions;
+using System.Text.Json;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Workloads.Workload.Install;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.TemplateEngine.Cli.Commands;
+
+namespace Microsoft.DotNet.Workloads.Workload.Search.Versions;
+
+internal class SearchWorkloadSetsCommand : WorkloadCommandBase
+{
+    internal readonly int NumberOfWorkloadSetsToTake;
+    private readonly SearchWorkloadSetsFormat _workloadSetOutputFormat;
+    internal readonly IWorkloadManifestInstaller Installer;
+    internal readonly ReleaseVersion SdkVersion;
+    private readonly IWorkloadResolver _workloadResolver;
+
+    private static readonly ManifestId WorkloadPackageIdBase = new("Microsoft.NET.Workloads");
+
+    public SearchWorkloadSetsCommand(ParseResult result, IWorkloadResolverFactory workloadResolverFactory = null, IReporter reporter = null) : base(result, reporter: reporter)
+    {
+        NumberOfWorkloadSetsToTake = result.HasOption(SearchWorkloadSetsParser.TakeOption) ? result.GetValue(SearchWorkloadSetsParser.TakeOption) : 5;
+        _workloadSetOutputFormat = result.GetValue(SearchWorkloadSetsParser.FormatOption);
+        workloadResolverFactory = workloadResolverFactory ?? new WorkloadResolverFactory();
+        var creationResult = workloadResolverFactory.Create();
+
+        SdkVersion = creationResult.SdkVersion;
+        _workloadResolver = creationResult.WorkloadResolver;
+
+        Installer = WorkloadInstallerFactory.GetWorkloadInstaller(
+                reporter,
+                new SdkFeatureBand(SdkVersion),
+                _workloadResolver,
+                Verbosity,
+                creationResult.UserProfileDir,
+                !SignCheck.IsDotNetSigned(),
+                restoreActionConfig: new RestoreActionConfig(result.HasOption(SharedOptions.InteractiveOption)),
+                elevationRequired: false,
+                shouldLog: false);
+    }
+
+    protected override void ShowHelpOrErrorIfAppropriate(ParseResult parseResult)
+    {
+
+    }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        var featureBand = new SdkFeatureBand(SdkVersion);
+        var packageId = Installer.GetManifestPackageId(WorkloadPackageIdBase, featureBand);
+        var versions = (await PackageDownloader.GetLatestPackageVersions(packageId, NumberOfWorkloadSetsToTake, packageSourceLocation: null, includePreview: !string.IsNullOrWhiteSpace(SdkVersion.Prerelease)).ConfigureAwait(false))
+            .Select(version => WorkloadManifestUpdater.WorkloadSetPackageVersionToWorkloadSetVersion(featureBand, version.Version.ToString()));
+        if (_workloadSetOutputFormat == SearchWorkloadSetsFormat.json)
+        {
+            Reporter.WriteLine(JsonSerializer.Serialize(versions.Select(version => version.ToDictionary(_ => "workloadVersion", v => v))));
+        }
+        else
+        {
+            Reporter.WriteLine(string.Join('\n', versions));
+        }
+
+        return 0;
+    }
+
+    public override int Execute() => Execute(CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Used for CLI completions to get the workload set versions.
+    /// </summary>
+    /// <returns></returns>
+    public static async Task<IEnumerable<string>> GetWorkloadSetVersions(CompletionContext ctx)
+    {
+        var inner = new SearchWorkloadSetsCommand(ctx.ParseResult);
+        var featureBand = new SdkFeatureBand(inner.SdkVersion);
+        var packageId = inner.Installer.GetManifestPackageId(WorkloadPackageIdBase, featureBand);
+        var versions = (await inner.PackageDownloader.GetLatestPackageVersions(packageId, inner.NumberOfWorkloadSetsToTake, packageSourceLocation: null, includePreview: !string.IsNullOrWhiteSpace(inner.SdkVersion.Prerelease)).ConfigureAwait(false))
+            .Select(version => WorkloadManifestUpdater.WorkloadSetPackageVersionToWorkloadSetVersion(featureBand, version.Version.ToString()));
+        return versions;
+    }
+}

--- a/src/Cli/dotnet/commands/dotnet-workload/search/versions/SearchWorkloadSetsParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-workload/search/versions/SearchWorkloadSetsParser.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using Microsoft.DotNet.Workloads.Workload.Search;
+using Microsoft.DotNet.Workloads.Workload.Search.Versions;
 using LocalizableStrings = Microsoft.DotNet.Workloads.Workload.Search.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli
     {
         public static readonly CliOption<int> TakeOption = new("--take") { DefaultValueFactory = (_) => 5 };
 
-        public static readonly CliOption<string> FormatOption = new("--format")
+        public static readonly CliOption<SearchWorkloadSetsFormat> FormatOption = new("--format")
         {
             Description = LocalizableStrings.FormatOptionDescription
         };
@@ -37,12 +37,15 @@ namespace Microsoft.DotNet.Cli
                 }
             });
 
-            command.SetAction(parseResult => new WorkloadSearchCommand(parseResult)
-            {
-                ListWorkloadSetVersions = true
-            }.Execute());
+            command.SetAction((parseResult, ct) => new SearchWorkloadSetsCommand(parseResult).Execute(ct));
 
             return command;
         }
+    }
+
+    internal enum SearchWorkloadSetsFormat
+    {
+        list,
+        json
     }
 }


### PR DESCRIPTION
Ok, I started playing around a bit and got tab-completion working for the `--version` option in the install and update commands.

The core problem here was I needed to extract out the 'get workload set versions' logic you'd created into something that could be called from the tab-completion context.  I also saw that you'd coded the functionality as an option on the workload search command - I disagree with this, the subcommand for listing versions should centralize this logic. So I pulled that out into a separate command, and then put the shared completions generation logic into a static member on this type that captures the logic involved.  Other notes inline!

To test this, build the app and run the dogfood script, then run `dotnet complete "dotnet workload install --version "` and you should get a list of versions out on stdout.